### PR TITLE
Add 4 Notion skills (Notion Devs)

### DIFF
--- a/skills.yaml
+++ b/skills.yaml
@@ -2901,3 +2901,60 @@ skills:
       - event-driven
       - lambda
       - architecture
+
+  - id: notion-meeting-intelligence
+    title: Notion Meeting Intelligence
+    description: Prepares meeting materials by gathering context from Notion, enriching with Claude research, and creating both an internal pre-read and external agenda saved to Notion. Helps you arrive prepared with a comprehensive background and structured meeting docs.
+    author: Notion Devs
+    author_url: https://notiondevs.notion.site/notion-skills-for-claude
+    skill_url: https://notiondevs.notion.site/notion-skills-for-claude
+    skill_download_url: https://notiondevs.notion.site/notion-skills-for-claude
+    tags:
+      - notion
+      - meetings
+      - preparation
+      - documentation
+      - research
+
+  - id: notion-research-documentation
+    title: Notion Research & Documentation
+    description: Searches across your Notion workspace, synthesizes findings from multiple pages, and creates comprehensive research documentation saved as new Notion pages. Turns scattered information into structured reports with proper citations and actionable insights.
+    author: Notion Devs
+    author_url: https://notiondevs.notion.site/notion-skills-for-claude
+    skill_url: https://notiondevs.notion.site/notion-skills-for-claude
+    skill_download_url: https://notiondevs.notion.site/notion-skills-for-claude
+    tags:
+      - notion
+      - research
+      - documentation
+      - synthesis
+      - reports
+
+  - id: notion-knowledge-capture
+    title: Notion Knowledge Capture
+    description: Turns discussions into durable knowledge in Notion. Captures insights and decisions from chat, formats them clearly, and files them to the right wiki or database with smart linking.
+    author: Notion Devs
+    author_url: https://notiondevs.notion.site/notion-skills-for-claude
+    skill_url: https://notiondevs.notion.site/notion-skills-for-claude
+    skill_download_url: https://notiondevs.notion.site/notion-skills-for-claude
+    tags:
+      - notion
+      - knowledge-management
+      - documentation
+      - wiki
+      - database
+
+  - id: notion-spec-to-implementation
+    title: Notion Spec to Implementation
+    description: Turns product or tech specs into concrete Notion tasks that Claude Code can implement. Breaks down spec pages into detailed implementation plans with clear tasks, acceptance criteria, and progress tracking to guide development from requirements to completion.
+    author: Notion Devs
+    author_url: https://notiondevs.notion.site/notion-skills-for-claude
+    skill_url: https://notiondevs.notion.site/notion-skills-for-claude
+    skill_download_url: https://notiondevs.notion.site/notion-skills-for-claude
+    tags:
+      - notion
+      - implementation
+      - planning
+      - tasks
+      - development
+      - specifications


### PR DESCRIPTION
This PR adds four Notion skills to skills.yaml:
- Meeting Intelligence
- Research & Documentation
- Knowledge Capture
- Spec to Implementation

Notes:
- author_github, license, and license_url are intentionally omitted as they were not available on the Notion page.
- skill_url and author_url point to https://notiondevs.notion.site/notion-skills-for-claude where the skills can be downloaded.
- All skills include the 'notion' tag along with other relevant tags.