### PR TITLE
Add Product-Manager-Skills listing

### DIFF
--- a/skills.yaml
+++ b/skills.yaml
@@ -20997,3 +20997,19 @@ skills:
   tags:
   - content
   - video
+- id: deanpeters-product-manager-skills
+  title: Product Manager Skills
+  description: 40+ PM-focused skills collection covering problem framing, discovery, opportunity selection, roadmaps, PRDs, prototypes, story splitting, and SaaS metrics.
+  author: Dean Peters
+  author_url: https://github.com/deanpeters
+  author_github: deanpeters
+  license: CC BY-NC-SA 4.0
+  license_url: https://raw.githubusercontent.com/deanpeters/Product-Manager-Skills/main/LICENSE
+  skill_url: https://github.com/deanpeters/Product-Manager-Skills
+  skill_download_url: https://github.com/deanpeters/Product-Manager-Skills
+  tags:
+  - product-management
+  - project-management
+  - strategy
+  - discovery
+  - saas


### PR DESCRIPTION
This PR adds `deanpeters/Product-Manager-Skills` to the Community Skills table.

Why this belongs:
- +40 PM-focused skills collection covering problem framing, discovery, opportunity selection,roadmaps, PRDs, prototypes, story splitting, and SaaS metrics.
- Public repo with active usage and social proof (21 stars as of Feb 11, 2026)
- Non-commercial, standalone value for Claude/Codex users
