### PR TITLE
Add legal skill listing

### DIFF
--- a/skills.yaml
+++ b/skills.yaml
@@ -20997,3 +20997,14 @@ skills:
   tags:
   - content
   - video
+- id: seandinwiddie-legal-skill
+  title: Legal
+  description: Draft and review startup legal documents with jurisdiction-aware checklists, contract redlines, founder paperwork guidance, filing references, and deadline tracking. Use when working on NDAs, consulting agreements, SAFEs, stock issuances and 83(b) elections, founder departures, provisional patent drafts, trademark filing prep, and startup-side contract review.
+  author: Sean Dinwiddie
+  author_url: https://github.com/seandinwiddie
+  author_github: seandinwiddie
+  skill_url: https://github.com/seandinwiddie/legal-skill
+  skill_download_url: https://github.com/seandinwiddie/legal-skill
+  tags:
+  - business
+  - documentation


### PR DESCRIPTION
## Summary
Adds the public  repository to the awesome-skills catalog.

## Skill
- Repo: https://github.com/seandinwiddie/legal-skill
- Scope: startup-side legal drafting, contract review, founder paperwork, filing guidance, and deadline tracking

## Notes
- The skill is published as a standalone public repo and already synced into local Claude/Codex/agents skill directories.
- Listing uses existing catalog fields only and does not add new schema.