### PR TITLE
Add X Twitter Scraper skill and harden HTML generation

### DIFF
--- a/generate_skills_json.py
+++ b/generate_skills_json.py
@@ -13,13 +13,18 @@ Also injects the JSON data into skills.html.
 from pathlib import Path
 import json
 import sys
-import re
 import yaml
 
 ROOT = Path(__file__).parent.resolve()
 YAML_PATH = ROOT / "skills.yaml"
 JSON_PATH = ROOT / "skills.json"
 HTML_PATH = ROOT / "skills.html"
+
+
+def json_for_html(data):
+    """Serialize data without allowing a value to close the script element."""
+    return json.dumps(data, ensure_ascii=False, separators=(',', ':'), default=str).replace('<', '\\u003c')
+
 
 def main():
     try:
@@ -61,7 +66,7 @@ def main():
             html_content = f.read()
         
         # Create the compact JSON string (single line, no extra whitespace)
-        json_str = json.dumps(data, ensure_ascii=False, separators=(',', ':'), default=str)
+        json_str = json_for_html(data)
         
         # Find and replace the content between the script tags
         updated_html = html_content

--- a/skills.yaml
+++ b/skills.yaml
@@ -20665,6 +20665,21 @@ skills:
   tags:
   - data
   - excel
+- id: xquik-dev-x-twitter-scraper-skills-x-twitter-scraper-skill-md
+  title: X Twitter Scraper
+  description: Use Xquik with AI agents for public X data workflows, including tweet search, user lookup, timelines, media downloads, monitors, webhooks, hosted MCP, and SDKs.
+  author: Xquik
+  author_url: https://github.com/Xquik-dev
+  author_github: Xquik-dev
+  license: MIT
+  license_url: https://raw.githubusercontent.com/Xquik-dev/x-twitter-scraper/master/LICENSE
+  skill_url: https://github.com/Xquik-dev/x-twitter-scraper/tree/master/skills/x-twitter-scraper
+  skill_download_url: https://raw.githubusercontent.com/Xquik-dev/x-twitter-scraper/master/skills/x-twitter-scraper/SKILL.md
+  tags:
+  - api
+  - automation
+  - data
+  - social-media
 - id: yai333-skillagentexample-skills-docx-skill-md
   title: Docx
   description: 'Comprehensive document creation, editing, and analysis with support for tracked changes, comments, formatting preservation, and text extraction. When Claude needs to work with professional documents (.docx files) for: (1) Creating new documents, (2) Modifying or editing content, (3) Working with tracked changes, (4) Adding comments, or any other document tasks'


### PR DESCRIPTION
## Summary

- Add the X Twitter Scraper skill to `skills.yaml`.
- Harden generated HTML against data that contains a closing script tag.
- Remove an unused Python import found by Ruff.
- Keep generated `skills.json` and `skills.html` out of the PR because the repository workflow regenerates them after merge.

## Xquik Skill

The entry links directly to the public skill, raw `SKILL.md`, and MIT license in `Xquik-dev/x-twitter-scraper`. It describes Xquik as an independent service and does not claim the service itself is open source.

## Independent Repository Fix

`generate_skills_json.py` previously embedded JSON into a script element without escaping `<`. A skill value containing `</script>` could terminate that element. The serializer now escapes `<` as `\u003c`, preserving the parsed JSON value while keeping the HTML script element intact.

## Validation

- Parsed `skills.yaml` and confirmed exactly 1 Xquik entry.
- Exercised the generator against a temporary skill containing `</script><script>` and verified the embedded HTML remains inside its script element.
- Verified the generated JSON still parses correctly.
- `uvx ruff check generate_skills_json.py`
- `python3 -m py_compile generate_skills_json.py`
- `git diff --check`
- Verified the skill page, raw skill, and license URLs return HTTP 200.

The automated Codex comment only reports a review-credit limit and contains no requested code change.

Resolves #28.

Disclosure: I am associated with Xquik.

Xquik is an independent third-party service. Not affiliated with X Corp. "Twitter" and "X" are trademarks of X Corp.
