### PR TITLE
Add AccInt Solve skill

### DIFF
--- a/skills.yaml
+++ b/skills.yaml
@@ -20997,3 +20997,18 @@ skills:
   tags:
   - content
   - video
+- id: maxbaluev-accreted-intelligence-plugins-claude-skills-solve-skill-md
+  title: AccInt Solve
+  description: Route Claude Code goals through AccInt's scored-memory loop, using retrieved prior work, continuation frames, and outcome feedback from a local-first MCP memory server.
+  author: Max Baluev
+  author_url: https://github.com/maxbaluev
+  author_github: maxbaluev
+  license: Apache-2.0
+  license_url: https://raw.githubusercontent.com/maxbaluev/accreted-intelligence/main/LICENSE-APACHE-2.0.txt
+  skill_url: https://github.com/maxbaluev/accreted-intelligence/tree/main/plugins/claude/skills/solve
+  skill_download_url: https://raw.githubusercontent.com/maxbaluev/accreted-intelligence/main/plugins/claude/skills/solve/SKILL.md
+  tags:
+  - ai
+  - development
+  - memory
+  - mcp


### PR DESCRIPTION
## Summary
- add AccInt Solve to the skills catalog
- point the catalog entry at the public Claude skill folder and raw SKILL.md
- include the Apache-2.0 license URL from the public AccInt repository

## Validation
- python3 in-memory load/render check for skills.yaml
- git diff --check
- verified raw SKILL.md URL returns HTTP 200
