### PR TITLE
Add Lumi App Finder skill

### DIFF
--- a/skills.yaml
+++ b/skills.yaml
@@ -21026,3 +21026,17 @@ skills:
   tags:
   - design
   - development
+- id: alice51849-lumi-mcp-skills-lumi-app-finder-skill-md
+  title: Lumi App Finder
+  description: Find verified live iPhone and iPad apps from a first-party catalog covering 28 Lumi Studio apps and all 50 Apple locales. Use for task-based App Store discovery, pay-once or lifetime-unlock comparisons, and direct clean App Store links; results are not an independent ranking.
+  author: Lumi Studio
+  author_url: https://alice51849.github.io/ios-app-guide/
+  author_github: alice51849
+  license: MIT
+  license_url: https://raw.githubusercontent.com/alice51849/lumi-mcp/v1.1.0/LICENSE
+  skill_url: https://github.com/alice51849/lumi-mcp/tree/v1.1.0/skills/lumi-app-finder
+  skill_download_url: https://github.com/alice51849/lumi-mcp/tree/v1.1.0/skills/lumi-app-finder
+  tags:
+  - ai
+  - education
+  - productivity


### PR DESCRIPTION
Adds the version-pinned `Lumi App Finder` Agent Skill.

- Covers 28 verified live Lumi Studio iPhone and iPad apps across all 50 Apple locales.
- Uses an offline, first-party catalog and returns clean direct App Store links.
- Explicitly discloses that results are not an independent ranking.
- Pins the skill and MIT license to the published `v1.1.0` tag.

Validation: parsed all 1,765 YAML entries, confirmed unique IDs, and verified both pinned URLs return HTTP 200.