### PR TITLE
Add NotFair SEO Drift skill

### DIFF
--- a/skills.yaml
+++ b/skills.yaml
@@ -21052,3 +21052,17 @@ skills:
   - ai
   - education
   - productivity
+- id: nowork-studio-notfair-seo-seo-drift-skill-md
+  title: NotFair SEO Drift
+  description: Snapshot a site's rankings, indexation, metadata, canonicals, robots directives, schema, and key on-page elements, then compare later snapshots to surface SEO regressions. This is an official MIT NotFair skill; Google Search Console data is optional and requires a hosted NotFair MCP connection.
+  author: NotFair
+  author_url: https://github.com/nowork-studio/NotFair
+  author_github: nowork-studio
+  license: MIT
+  license_url: https://raw.githubusercontent.com/nowork-studio/NotFair/main/LICENSE
+  skill_url: https://github.com/nowork-studio/NotFair/tree/main/seo/seo-drift
+  skill_download_url: https://github.com/nowork-studio/NotFair/tree/main/seo/seo-drift
+  tags:
+  - analytics
+  - monitoring
+  - web


### PR DESCRIPTION
## Summary

Add the official MIT-licensed NotFair `seo-drift` skill to `skills.yaml`. The skill snapshots and compares rankings, indexation, metadata, canonical/robots directives, schema, and key on-page elements to surface SEO regressions.

## Disclosure

I am affiliated with NotFair / `nowork-studio`, which publishes the linked skill. The skill files are public in the MIT-licensed repository. Connected Google Search Console data is optional and requires a hosted NotFair MCP connection; the entry states this explicitly.

## Validation

- parsed `skills.yaml` successfully (1,767 unique IDs)
- confirmed the new entry contains every field used by comparable listings
- `git diff --check` passes
- repository, skill, license, and raw `SKILL.md` URLs return HTTP 200