### PR TITLE
Add Shopify Review Triage skill

### DIFF
--- a/skills.yaml
+++ b/skills.yaml
@@ -21066,3 +21066,17 @@ skills:
   - analytics
   - monitoring
   - web
+- id: alfredtech2026-shopify-app-review-brief-docs-skills-shopify-review-triage-skill-md
+  title: Shopify Review Triage
+  description: Turn rows of public Shopify App Store review text into a prioritized P0-P3 brief covering incident risk, repeated friction, pricing confusion, feature requests, and an explicit needs-human-read bucket. Every item keeps its public source link and is labeled first pass or human-checked, reviews are treated as customer reports rather than verified defects, and no message is ever sent on the team's behalf. Needs no network access, scripts, or system packages. Independent and not affiliated with Shopify Inc.
+  author: alfredtech2026
+  author_url: https://github.com/alfredtech2026
+  author_github: alfredtech2026
+  license: MIT
+  license_url: https://raw.githubusercontent.com/alfredtech2026/shopify-app-review-brief/main/LICENSE
+  skill_url: https://github.com/alfredtech2026/shopify-app-review-brief/tree/main/docs/skills/shopify-review-triage
+  skill_download_url: https://github.com/alfredtech2026/shopify-app-review-brief/tree/main/docs/skills/shopify-review-triage
+  tags:
+  - business
+  - analytics
+  - productivity


### PR DESCRIPTION
Adds one entry to `skills.yaml` for the `shopify-review-triage` Agent Skill.

## What the skill does

Takes rows of **public** Shopify App Store review text and produces a prioritized P0–P3 brief: incident risk, repeated friction, pricing confusion, feature requests, and an explicit *needs-human-read* bucket. Every item keeps its public source link and is labeled *first pass* or *human-checked*. Reviews are written up as customer reports, not verified defects, and the skill never sends or posts anything on the team's behalf.

It is a plain `SKILL.md` — no network access, no scripts, no system packages — so it is portable to any agent or client supporting the Agent Skills format.

## Disclosures

- **I maintain the linked skill.** It lives in my own public repository, `alfredtech2026/shopify-app-review-brief`, and I authored it.
- **AI assistance was used** to prepare this contribution: Claude Code (Opus 5) researched the repository's contribution process, drafted the catalog entry, and ran the validation below.
- The skill is independent and not affiliated with Shopify Inc.

## Entry details

- License: MIT (`LICENSE` in the linked repo)
- `skill_url` / `skill_download_url`: the canonical skill directory on GitHub
- Tags: `business`, `analytics`, `productivity` — all already in use in `skills.yaml`
- No price, contact, UTM parameters, or promotional copy in the entry

## Validation performed

- `skills.yaml` parses cleanly with `yaml.safe_load`; entry count 1767 → 1768, top-level shape unchanged.
- Ran the repo's own `generate_skills_json.py` against the modified file **in a scratch copy** (not committed): exits 0, produces 1768 entries in `skills.json`, and injects into `skills.html` successfully. Per the existing workflow and recent merged PRs, only `skills.yaml` is committed here — CI regenerates `skills.json`/`skills.html` on merge to `main`.
- Field set matches the established schema exactly (no unknown keys, all commonly-required keys present); `id` and `title` are unique across the file; all three tags already exist in the vocabulary.
- `git diff --check` clean; diff is a single 14-line addition to `skills.yaml` and touches nothing else.
- Every submitted URL fetched live and returns HTTP 200 with the expected content: the skill directory, the raw `LICENSE` (begins "MIT License"), and the author profile. The `SKILL.md` at the linked path resolves with `name: shopify-review-triage`.

No runtime/integration tests were run as part of this PR beyond the checks listed above.